### PR TITLE
Potencial Deadlock fix

### DIFF
--- a/genesis/consumer.py
+++ b/genesis/consumer.py
@@ -4,7 +4,7 @@ Consumer Module
 Simple abstraction used to put some syntactic sugar into freeswitch event consumption.
 """
 
-from typing import Awaitable, NoReturn, Callable, Optional
+from typing import Callable, Optional, Coroutine, Union
 import functools
 import asyncio
 import re
@@ -13,9 +13,9 @@ from genesis.inbound import Inbound
 from genesis.logger import logger
 
 
-def filtrate(key: str, value: Optional[str] = None, regex: bool = False):
+def filtrate(key: str, value: Optional[str] = None, regex: bool = False) -> Union[Callable, Coroutine]:
     """
-    Method that allows to filter the events accordingto a set 'key', 'value'.
+    Method that allows to filter the events according to a set 'key', 'value'.
 
     Parameters
     ----------
@@ -27,7 +27,7 @@ def filtrate(key: str, value: Optional[str] = None, regex: bool = False):
         Tells whether 'value' is a regular expression.
     """
 
-    def decorator(function: Awaitable):
+    def decorator(function: Union[Callable, Coroutine]):
         @functools.wraps(function)
         async def wrapper(message):
             if isinstance(message, dict):
@@ -74,7 +74,7 @@ class Consumer:
     ) -> None:
         self.protocol: Inbound = Inbound(host, port, password, timeout)
 
-    def handle(self, event: str) -> Callable:
+    def handle(self, event: str) -> Union[Callable, Coroutine]:
         """Decorator that allows the registration of new handlers.
 
         Parameters
@@ -83,7 +83,7 @@ class Consumer:
             Name of the event to be parsed.
         """
 
-        def decorator(function: Awaitable):
+        def decorator(function: Union[Callable, Coroutine]):
             self.protocol.on(event, function)
 
             @functools.wraps(function)
@@ -94,12 +94,12 @@ class Consumer:
 
         return decorator
 
-    async def wait(self) -> Awaitable[NoReturn]:
+    async def wait(self) -> None:
         while bool(self.protocol.is_connected):
             logger.debug("Wait to recive new events...")
             await asyncio.sleep(1)
 
-    async def start(self) -> Awaitable[NoReturn]:
+    async def start(self) -> None:
         """Method called to request the freeswitch to start sending us the appropriate events."""
         try:
             async with self.protocol as protocol:
@@ -128,5 +128,5 @@ class Consumer:
             await self.stop()
             raise
 
-    async def stop(self) -> Awaitable[NoReturn]:
-        return await self.protocol.stop()
+    async def stop(self) -> None:
+        await self.protocol.stop()

--- a/genesis/consumer.py
+++ b/genesis/consumer.py
@@ -96,7 +96,7 @@ class Consumer:
 
     async def wait(self) -> None:
         while bool(self.protocol.is_connected):
-            logger.debug("Wait to recive new events...")
+            logger.debug("Wait to receive new events...")
             await asyncio.sleep(1)
 
     async def start(self) -> None:

--- a/genesis/parser.py
+++ b/genesis/parser.py
@@ -4,7 +4,7 @@ Genesis parse
 It implements the intelligence necessary for us to transform freeswitch events into python primitive types.
 """
 
-from typing import Dict, List, Union, Optional
+from typing import Optional
 from collections import UserDict
 from urllib.parse import unquote
 

--- a/genesis/protocol.py
+++ b/genesis/protocol.py
@@ -13,6 +13,7 @@ from asyncio import (
     Event,
     Queue,
     Task,
+    to_thread,
 )
 from typing import List, Awaitable, Dict, NoReturn, Optional, Callable, Coroutine, Any, Union
 from inspect import isawaitable
@@ -39,7 +40,7 @@ class Protocol(ABC):
             Callable[[ESLEvent], Coroutine[Any, Any, None]]
         ]]] = {}
 
-    async def start(self) -> NoReturn:
+    async def start(self) -> None:
         """Initiates a connection to a freeswitch."""
         self.is_connected = True
 
@@ -50,7 +51,7 @@ class Protocol(ABC):
     async def stop(self) -> None:
         """Terminates connection to a freeswitch."""
         if self.writer and not self.writer.is_closing():
-            logger.debug("Closer stream writter.")
+            logger.debug("Closer stream writer.")
             self.writer.close()
 
         self.is_connected = False
@@ -80,6 +81,7 @@ class Protocol(ABC):
 
                 if buffer[-2:] == "\n\n" or buffer[-4:] == "\r\n\r\n":
                     request = buffer
+                    logger.debug(f"<<< Complete message received: {repr(request)}")
                     break
 
             if not request or not self.is_connected:
@@ -89,23 +91,18 @@ class Protocol(ABC):
 
             if "Content-Length" in event:
                 length = int(event["Content-Length"])
-
                 logger.debug(f"Read more {length} bytes.")
                 data = await self.reader.readexactly(length)
-                logger.debug(f"Recidev data: {data}")
+                logger.debug(f"Received data: {data}")
                 result = data.decode("utf-8")
 
                 if "Content-Type" in event:
                     content = event["Content-Type"]
                     logger.debug(f"Check content type of event: {event}")
 
-                    if content not in [
-                        "api/response",
-                        "text/rude-rejection",
-                        "log/data",
-                    ]:
+                    if content not in ["api/response", "text/rude-rejection", "log/data"]:
                         headers = parse_headers(result)
-                        logger.debug(f"Recived headers: {headers}")
+                        logger.debug(f"Received headers: {headers}")
 
                         if "Content-Length" in headers:
                             length = int(headers["Content-Length"])
@@ -113,7 +110,7 @@ class Protocol(ABC):
                             data = await self.reader.readexactly(length)
                             result = data.decode("utf-8")
 
-                            logger.debug(f"Recived body: {result}")
+                            logger.debug(f"Received body: {result}")
                             event.body = result
 
                         event.update(headers)
@@ -129,7 +126,7 @@ class Protocol(ABC):
         """Arm all event processors."""
         while self.is_connected:
             event = await self.events.get()
-            logger.debug(f"Recived an event: '{event}'.")
+            logger.debug(f"Received an event: '{event}'.")
 
             if "Content-Type" in event and event["Content-Type"] == "auth/request":
                 self.authentication_event.set()
@@ -165,8 +162,10 @@ class Protocol(ABC):
 
                 if handlers:
                     for handler in handlers:
-                        if isawaitable(handler) or iscoroutinefunction(handler):
-                            await handler(event)
+                        if iscoroutinefunction(handler):
+                            create_task(handler(event))
+                        else:
+                            create_task(to_thread(handler, event))
 
     def on(self, key: str, handler: Union[
            Callable[[ESLEvent], None],
@@ -182,7 +181,7 @@ class Protocol(ABC):
         if key in self.handlers and handler in self.handlers[key]:
             self.handlers.setdefault(key, list()).remove(handler)
 
-    async def send(self, cmd: str) -> Awaitable[ESLEvent]:
+    async def send(self, cmd: str) -> ESLEvent:
         """Method used to send commands to or freeswitch."""
         if not self.is_connected:
             raise UnconnectedError()

--- a/genesis/protocol.py
+++ b/genesis/protocol.py
@@ -175,7 +175,10 @@ class Protocol(ABC):
         logger.debug(f"Register handler to '{key}' event.")
         self.handlers.setdefault(key, list()).append(handler)
 
-    def remove(self, key: str, handler: Awaitable[None]) -> None:
+    def remove(self, key: str, handler: Union[
+           Callable[[ESLEvent], None],
+           Callable[[ESLEvent], Coroutine[Any, Any, None]]
+       ]) -> None:
         """Removes the HANDLER from the list of handlers for the given event KEY name."""
         logger.debug(f"Remove handler to '{key}' event.")
         if key in self.handlers and handler in self.handlers[key]:


### PR DESCRIPTION
Hey,

i've got a deadlock when i've tried to use "send" inside a handler, for example:

```python
from genesis import Session

class MyCall:
    def __init__(self, session: Session):
        self.session = session
        self.session.on('CHANNEL_BRIDGE', self.on_bridge)
        ...

    async def on_bridge(self, event):
        filter_output = await self.session.send(f"filter Unique-ID {event['Other-Leg-Unique-ID']}")
        print(filter_output)
        ...
```
The `print(filter_output)` will never run, cause the consumer is still stuck in the `on_bridge` handler and doesn't process the answer from the send command.

So i pushed the handlers in it's own tasks with:

```python
if iscoroutinefunction(handler):
      create_task(handler(event))
  else:
      create_task(to_thread(handler, event))
```
That works for me, but i'm not sure that there aren't any side effects i don't know about. ⚠️ ⚠️ ⚠️ 

And i've fixed some typos and type hints. 

I've read into the "-> Awaitable[Something]" return values and you can skip that and just write "-> Something", cause the async already implies the "Awaitable".