### PR TITLE
Fix for #28 - ESLEvent.body is now also a dictionary key.

### DIFF
--- a/genesis/parser.py
+++ b/genesis/parser.py
@@ -11,8 +11,17 @@ from urllib.parse import unquote
 
 class ESLEvent(UserDict):
     def __init__(self, *args, **kwargs):
+        self._body = kwargs.pop('body', None)
         super().__init__(*args, **kwargs)
-        self.body: Optional[str] = None
+
+    @property
+    def body(self) -> Optional[str]:
+        return self._body
+
+    @body.setter
+    def body(self, value: Optional[str]):
+        self._body = value
+        self.data['body'] = value
 
 
 def parse_headers(payload: str) -> ESLEvent:

--- a/genesis/protocol.py
+++ b/genesis/protocol.py
@@ -156,11 +156,14 @@ class Protocol(ABC):
                             continue  # Skip the final event.put
 
                         else:
+                            logger.trace("No clear header/body separation found")
                             # If no clear header/body separation, treat everything as body
                             event.body = complete_content
                     else:
+                        logger.trace("Content-Type is api/response, text/rude-rejection or log/data")
                         event.body = complete_content
                 else:
+                    logger.trace("No Content-Type found")
                     event.body = complete_content
 
             await self.events.put(event)


### PR DESCRIPTION
It's possible to get the body data in #28 with `response.body`, but it's a UserDict, so i think it should also be a key.