### PR TITLE
Add sendmsg parameters for channels, execution tracking and blocking

### DIFF
--- a/genesis/outbound.py
+++ b/genesis/outbound.py
@@ -117,8 +117,6 @@ class Session(Protocol):
             if not event_uuid:
                 event_uuid = str(uuid4())
             cmd += f"\nEvent-UUID: {event_uuid}"
-        else:
-            cmd += f"\nEvent-UUID: {uuid4()}"
 
         if command == "hangup":
             cmd += f"\nhangup-cause: {data}"

--- a/genesis/outbound.py
+++ b/genesis/outbound.py
@@ -103,11 +103,11 @@ class Session(Protocol):
                 Additional headers to send with the command.
         """
         if uuid:
-            cmd = f"sendmsg {uuid}\n"
+            cmd = f"sendmsg {uuid}"
         else:
-            cmd = "sendmsg\n"
+            cmd = "sendmsg"
 
-        cmd += f"call-command: {command}\n"
+        cmd += f"\ncall-command: {command}"
 
         # Generate event_uuid if not provided and command is execute
         if command == "execute":

--- a/genesis/outbound.py
+++ b/genesis/outbound.py
@@ -11,6 +11,7 @@ from asyncio import StreamReader, StreamWriter, Queue, start_server, Event
 from collections.abc import Callable, Coroutine
 from typing import Optional, Union, Dict
 from functools import partial
+from uuid import uuid4
 import socket
 
 from genesis.protocol import Protocol
@@ -48,12 +49,13 @@ class Session(Protocol):
         """Interface used to implement a context manager."""
         await self.stop()
 
-    async def _awaitable_complete_command(self, application: str) -> Event:
+    async def _awaitable_complete_command(self, application: str, event_uuid: str) -> Event:
         """
         Create an event that will be set when a command completes.
 
         Args:
             application: Name of the application to wait for completion
+            event_uuid: UUID to track the specific command execution
 
         Returns:
             Event that will be set when command completes
@@ -63,22 +65,46 @@ class Session(Protocol):
         async def handler(session: Session, event: ESLEvent):
             logger.debug(f"Received channel execute complete event: {event}")
 
-            if "variable_current_application" in event:
-                if event["variable_current_application"] == application:
-                    await session.fifo.put(event)
-                    semaphore.set()
-                    self.remove("CHANNEL_EXECUTE_COMPLETE", handler)
+            if "Application-UUID" in event and event["Application-UUID"] == event_uuid:
+                await session.fifo.put(event)
+                semaphore.set()
+                self.remove("CHANNEL_EXECUTE_COMPLETE", handler)
 
-        logger.debug(f"Register event handler to {application} complete event")
+        logger.debug(f"Register event handler for Application-UUID: {event_uuid}")
         self.on("CHANNEL_EXECUTE_COMPLETE", partial(handler, self))
 
         return semaphore
 
     async def sendmsg(
-        self, command: str, application: str, data: Optional[str] = None, lock=False
+        self, command: str, application: str, data: Optional[str] = None, lock: bool = False, 
+        uuid: Optional[str] = None, event_uuid: Optional[str] = None, block: bool = False
     ) -> ESLEvent:
-        """Used to send commands from dialplan to session."""
-        cmd = f"sendmsg\ncall-command: {command}\nexecute-app-name: {application}"
+        """
+        Used to send commands from dialplan to session.
+
+        Args:
+            command: required
+                Command to send to freeswitch. One of: execute, hangup, unicast, nomedia, xferext
+            application: required
+                Dialplan application to execute.
+            data: optional
+                Arguments to send to the application. If the command is 'hangup', this is the cause.
+            lock: optional
+                If true, lock the event.
+            uuid: optional
+                UUID of the call/session/channel to send the command.
+            event_uuid: optional
+                Adds a UUID to the execute command. In the corresponding events (CHANNEL_EXECUTE and
+                CHANNEL_EXECUTE_COMPLETE), the UUID will be in the Application-UUID header.
+            block: optional
+                If true, wait for command completion before returning.
+        """
+        if uuid:
+            cmd = f"sendmsg {uuid}\n"
+        else:
+            cmd = "sendmsg\n"
+
+        cmd += f"call-command: {command}\nexecute-app-name: {application}"
 
         if data:
             cmd += f"\nexecute-app-arg: {data}"
@@ -86,7 +112,26 @@ class Session(Protocol):
         if lock:
             cmd += f"\nevent-lock: true"
 
+        # Generate event_uuid if not provided and command is execute
+        if command == "execute":
+            if not event_uuid:
+                event_uuid = str(uuid4())
+            cmd += f"\nEvent-UUID: {event_uuid}"
+        else:
+            cmd += f"\nEvent-UUID: {uuid4()}"
+
+        if command == "hangup":
+            cmd += f"\nhangup-cause: {data}"
+
         logger.debug(f"Send command to freeswitch: '{cmd}'.")
+        
+        if block and command == "execute":
+            logger.debug(f"Waiting for command completion with Application-UUID: {event_uuid}")
+            command_is_complete = await self._awaitable_complete_command(application, event_uuid)
+            response = await self.send(cmd)
+            await command_is_complete.wait()
+            return await self.fifo.get()
+        
         return await self.send(cmd)
 
     async def answer(self) -> ESLEvent:
@@ -103,17 +148,7 @@ class Session(Protocol):
 
     async def playback(self, path: str, block=True) -> ESLEvent:
         """Requests the freeswitch to play an audio."""
-        if not block:
-            return await self.sendmsg("execute", "playback", path)
-
-        logger.debug("Send playback command to freeswitch with block behavior.")
-        command_is_complete = await self._awaitable_complete_command("playback")
-        response = await self.sendmsg("execute", "playback", path)
-
-        logger.debug("Await playback complete event...")
-        await command_is_complete.wait()
-
-        return response
+        return await self.sendmsg("execute", "playback", path, block=block)
 
     async def say(
         self,
@@ -131,22 +166,7 @@ class Session(Protocol):
 
         arguments = f"{module} {kind} {method} {gender} {text}"
         logger.debug(f"Arguments used in say command: {arguments}")
-
-        if not block:
-            return await self.sendmsg("execute", "say", arguments)
-
-        logger.debug("Send say command to freeswitch with block behavior.")
-        command_is_complete = await self._awaitable_complete_command("say")
-        response = await self.sendmsg("execute", "say", arguments)
-        logger.debug(f"Response of say command: {response}")
-
-        logger.debug("Await say complete event...")
-        await command_is_complete.wait()
-
-        event = await self.fifo.get()
-        logger.debug(f"Execute complete event received: {event}")
-
-        return event
+        return await self.sendmsg("execute", "say", arguments, block=block)
 
     async def play_and_get_digits(
         self,
@@ -180,26 +200,8 @@ class Session(Protocol):
         formated_ordered_arguments = map(formatter, ordered_arguments)
         arguments = " ".join(formated_ordered_arguments)
         logger.debug(f"Arguments used in play_and_get_digits command: {arguments}")
-
-        if not block:
-            return await self.sendmsg("execute", "play_and_get_digits", arguments)
-
-        logger.debug(
-            "Send play_and_get_digits command to freeswitch with block behavior."
-        )
-        command_is_complete = await self._awaitable_complete_command(
-            "play_and_get_digits"
-        )
-        response = await self.sendmsg("execute", "play_and_get_digits", arguments)
-        logger.debug(f"Response of play_and_get_digits command: {response}")
-
-        logger.debug("Await play_and_get_digits complete event...")
-        await command_is_complete.wait()
-
-        event = await self.fifo.get()
-        logger.debug(f"Execute complete event received: {event}")
-
-        return event
+        
+        return await self.sendmsg("execute", "play_and_get_digits", arguments, block=block)
 
 
 class Outbound:

--- a/tests/test_outbound.py
+++ b/tests/test_outbound.py
@@ -222,14 +222,14 @@ async def test_outbound_session_sendmsg_parameters(host, port, dialplan, monkeyp
 
     test_cases = [
         {
-            "args": ("execute", "playback", "/tmp/test.wav", True),
+            "args": ("execute", "playback", "/tmp/test.wav"),
             "kwargs": {"lock": True},
             "desc": "with lock"
         },
         {
             "args": ("execute", "playback", "/tmp/test.wav"),
             "kwargs": {"uuid": "test-uuid-1234"},
-            "desc": "with uuid" 
+            "desc": "with uuid"
         },
         {
             "args": ("execute", "playback", "/tmp/test.wav"),
@@ -254,7 +254,7 @@ async def test_outbound_session_sendmsg_parameters(host, port, dialplan, monkeyp
 
     address = (host(), port())
     app = Outbound(handler, *address)
-    
+
     await app.start(block=False)
     await dialplan.start(*address)
     await app.stop()
@@ -262,4 +262,7 @@ async def test_outbound_session_sendmsg_parameters(host, port, dialplan, monkeyp
 
     # Verify all calls were made with correct parameters
     for case in test_cases:
-        spider.assert_any_call(*case["args"], **case["kwargs"])
+        expected_args = case["args"]
+        expected_kwargs = case["kwargs"]
+        spider.assert_any_call(*expected_args, **expected_kwargs)
+


### PR DESCRIPTION
I've learned there are some very handy [parameters to sendmsg in the event socket](https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Modules/mod_event_socket_1048924/#39-sendmsg):

- You can add the uuid of a channel/leg to execute an application on it. That way you can originate a fresh channel with api/bgapi and run stuff on it like it was a inbound call. And you can control calls outside the current session.
- You can add the "Event-UUID" header with your own uuid and track the execution of your call with it. That way you can match the "CHANNEL_EXECUTE_COMPLETE" event very accurate. Until now you only watch for a complete event that matches you application, but what if you fired the same application twice at the same time, but with different parameters? That's now possible without any headaches.
- The block parameter moves the waiting for the response into the `sendmsg` methode, That saves some lines of code, cause it's needed in so many application calls.
- Added handling for hangup to give a proper "hangup-cause" in the data parameter. That's an alternative to the dialplan application.
- Added a headers dict parameter. With that you can add custom headers to use for example the `unicast` command. With that the method get's very flexible.
- Added a test for the parameters

I've experimented with the "lock" parameter and it's rather useless in most scenarios, cause it blocks all other events until the execution is done. There are better ways instead. But for compatibility reasons we should leave it, since it's there for a while.
