### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,34 @@ ESL is a way to communicate with FreeSwitch. See more details [here](https://fre
 
 ## Why asyncio?
 
+
 Asynchronous programming is a type of parallel programming in which a unit of work is allowed to run separately from the primary application thread. When the work is complete, it notifies the main thread about completion or failure of the worker thread. There are numerous benefits to using it, such as improved application performance and enhanced responsiveness. We adopted this way of working, as integrating genesis with other applications is simpler, since you only need to deal with python's native asynchronous programming interface.
+
+## Installation
+
+Install Genesis using pip:
+
+```bash
+pip install genesis
+```
 
 ## Docs
 
-The project documentation is in [here](https://github.com/Otoru/Genesis/wiki).
+Full documentation is available on the [documentation website](https://otoru.github.io/Genesis/).
+To preview the docs locally, install [Hugo](https://gohugo.io) and run:
+
+```bash
+hugo --source docs --serve
+```
+
+## Running tests
+
+Install development dependencies with [Poetry](https://python-poetry.org) and execute the test suite using [tox](https://tox.wiki):
+
+```bash
+poetry install
+tox
+```
 
 ## How to contribute?
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,6 +1,16 @@
 # Welcome to the Genesis docs
 
-Genesis is a python library designed to build applications (with asyncio) that work with freeswitch through ESL.
+Genesis is a Python library that helps you build applications for
+[FreeSWITCH](https://freeswitch.org/) using `asyncio`. Here you will find
+guides and references to get your projects up and running quickly.
+
+Genesis provides three core building blocks:
+
+- **Inbound mode** for sending commands directly to FreeSWITCH.
+- **Consumer mode** to process events asynchronously.
+- **Outbound mode** for creating dialplan-driven services.
+
+In addition, a small CLI is included to launch your applications.
 
 ## What is Freeswitch?
 
@@ -18,4 +28,10 @@ Asynchronous programming is a type of parallel programming in which a unit of wo
 
 ## How to start?
 
-Start by following the [Installation](https://github.com/Otoru/Genesis/wiki/Installation) process described in the documentation and then take a look at our [quickstart](https://github.com/Otoru/Genesis/wiki/Quickstart) to learn how to work using genesis.
+Start by following the [Installation](/docs/Installation/) process described in the documentation and then take a look at our [quickstart](/docs/Quickstart/) to learn how to work using Genesis.
+
+## Next steps
+
+- Get familiar with the [CLI](/docs/CLI/) commands.
+- Explore the [Tools](/docs/Tools/) page for helper utilities.
+- Dive into the [ESL events structure](/docs/ESL-events-structure/) guide to understand how FreeSWITCH messages are represented.

--- a/docs/content/docs/CLI/_index.md
+++ b/docs/content/docs/CLI/_index.md
@@ -1,0 +1,72 @@
+---
+menu:
+  main:
+    identifier: "cli"
+    weight: 3
+---
+# Command Line Interface
+
+The Genesis CLI provides commands to run and manage your FreeSWITCH Event Socket applications. Below are the available commands and their usage.
+
+## Usage
+
+```bash
+genesis [OPTIONS] COMMAND [ARGS]...
+```
+
+## Options
+
+Option | Description
+-- | --
+--version | Show the version and exit.
+
+## genesis consumer
+
+Run your ESL events consumer.
+
+### Usage
+
+```bash
+genesis consumer [OPTIONS] PATH
+```
+
+### Options
+
+Option | Description | Default
+-- | -- | --
+--host TEXT | The host to connect on. | 127.0.0.1
+--port INTEGER | The port to connect on. | 8021
+--password TEXT | The password to authenticate on host. | ClueCon
+--app TEXT | Variable that contains the Consumer app in the imported module or package. | None
+--loglevel TEXT | The log level to use. | info
+
+### Example
+
+```bash
+genesis consumer /path/to/your/app --host 192.168.1.100 --port 8021 --password MySecretPassword --loglevel debug
+```
+
+## genesis outbound
+
+Run your outbound services.
+
+### Usage
+
+```bash
+genesis outbound [OPTIONS] PATH
+```
+
+### Options
+
+Option | Description | Default
+-- | -- | --
+--host TEXT | The host to serve on. | 127.0.0.1
+--port INTEGER | The port to serve on. | 9000
+--app TEXT | Variable that contains the Outbound app in the imported module or package. | None
+--loglevel TEXT | The log level to use. | info
+
+### Example
+
+```bash
+genesis outbound /path/to/your/app --host 192.168.1.100 --port 9000 --loglevel debug
+```

--- a/docs/content/docs/Installation/_index.md
+++ b/docs/content/docs/Installation/_index.md
@@ -14,4 +14,4 @@ Within the environment you want to use to work, use the following command to ins
 pip install genesis 
 ```
 
-Genesis is now installed. Go to the [documentation](https://github.com/Otoru/Genesis/wiki) overview to start to work.
+Genesis is now installed. Visit the [documentation homepage](/) to start exploring the available guides.

--- a/docs/content/docs/Tools/_index.md
+++ b/docs/content/docs/Tools/_index.md
@@ -2,78 +2,12 @@
 menu:
   main:
     identifier: "tools"
-    weight: 3
+    weight: 4
 ---
 # tools
 
 Here we will list some methods that may be useful during the development of a Genesis project.
 
-## Command Line Interface
-
-The Genesis CLI provides commands to run and manage your FreeSWITCH Event Socket applications. Below are the available commands and their usage.
-
-### Usage
-
-```bash
-genesis [OPTIONS] COMMAND [ARGS]...
-```
-
-### Options
-
-Option | Description
--- | --
---version | Show the version and exit.
-
-### genesis consumer
-
-Run your ESL events consumer.
-
-#### Usage
-
-```bash
-genesis consumer [OPTIONS] PATH
-```
-
-#### Options
-
-Option | Description | Default
--- | -- | --
---host TEXT | The host to connect on. | 127.0.0.1
---port INTEGER | The port to connect on. | 8021
---password TEXT | The password to authenticate on host. | ClueCon
---app TEXT | Variable that contains the Consumer app in the imported module or package. | None
---loglevel TEXT | The log level to use. | info
-
-#### Example
-
-```bash
-genesis consumer /path/to/your/app --host 192.168.1.100 --port 8021 --password MySecretPassword --loglevel debug
-```
-
-### genesis outbound
-
-Run your outbound services.
-
-#### Usage
-
-```bash
-genesis outbound [OPTIONS] PATH
-```
-
-#### Options
-
-Option | Description | Default
--- | -- | --
---host TEXT | The host to serve on. | 127.0.0.1
---port INTEGER | The port to serve on. | 9000
---app TEXT | Variable that contains the Outbound app in the imported module or package. | None
---loglevel TEXT | The log level to use. | info
-
-#### Example
-
-```bash
-genesis outbound /path/to/your/app --host 192.168.1.100 --port 9000 --loglevel debug
-```
 
 ## Filtrate
 

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://otoru.github.io/genesis'
+baseURL = 'https://otoru.github.io/Genesis/'
 languageCode = 'en-us'
 title = 'Genesis'
 theme = 'book'

--- a/genesis/cli/__init__.py
+++ b/genesis/cli/__init__.py
@@ -40,5 +40,5 @@ def callback(
 
     Run yours freeswitch apps without any external dependencies.
 
-    ℹ️ Read more in the docs: [link]https://github.com/Otoru/Genesis/wiki[/link].
+    ℹ️ Read more in the docs: [link]https://otoru.github.io/Genesis/[/link].
     """


### PR DESCRIPTION
## Summary
- fix FreeSWITCH reference in overview page
- add a dedicated CLI documentation page
- update Tools page weight and move CLI docs
- link to CLI page from the docs index
- fix heading levels in CLI page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b22cb5cac8325aa473208fed9e27a