### PR TITLE
fix(#41): prevent blocking in _awaitable_complete_command by properly binding event handlers

### DIFF
--- a/genesis/outbound.py
+++ b/genesis/outbound.py
@@ -99,7 +99,7 @@ class Session(Protocol):
         handlers["CHANNEL_HANGUP_COMPLETE"] = channel_hangup_complete_handler
 
         for key, value in handlers.items():
-            self.on(key, value)
+            self.on(key, partial(value, self))
 
         logger.debug(f"Register event handler for Application-UUID: {event_uuid}")
 


### PR DESCRIPTION
The event handlers inside _awaitable_complete_command were registered without binding `self`, which caused them to silently fail and never be triggered. As a result, the command would block indefinitely or until timeout, even when the expected events were received.

This commit wraps the handlers with `functools.partial` to ensure `self` is correctly passed, allowing the handlers to function as intended and the semaphore to be set on completion.