### PR TITLE
fix: bump PyJWT to 2.12.1 (CVE-2026-32597)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1031,15 +1031,19 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 description = "JSON Web Token implementation in Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"redis\""
 files = [
-    {file = "pyjwt-2.12.0-py3-none-any.whl", hash = "sha256:9bb459d1bdd0387967d287f5656bf7ec2b9a26645d1961628cda1764e087fd6e"},
-    {file = "pyjwt-2.12.0.tar.gz", hash = "sha256:2f62390b667cd8257de560b850bb5a883102a388829274147f1d724453f8fb02"},
+    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
+    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
 ]
+
+[package.dependencies]
+typing_extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]


### PR DESCRIPTION
## Summary

- Bumps `PyJWT` from 2.10.1 to 2.12.1 in `poetry.lock`
- PyJWT is a transitive dependency pulled in by the optional `redis` extra
- Fixes GHSA-752w-5fwx-jx9f / CVE-2026-32597 (CVSS 7.5 HIGH)

**Vulnerability:** PyJWT <= 2.11.0 does not validate the `crit` (Critical) Header Parameter per RFC 7515 §4.1.11. Tokens with unknown critical extensions are silently accepted instead of rejected, enabling security policy bypass (MFA, token binding, scope restrictions).

Closes https://github.com/Otoru/Genesis/security/dependabot/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)