### PR TITLE
fix: add explicit permissions to workflow jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
   check-commit:
     name: Check Commit Source
     runs-on: ubuntu-latest
+    permissions: {}
     if: always()
     outputs:
       should-run: ${{ steps.check.outputs.should-run || steps.check-pr.outputs.should-run }}
@@ -60,6 +61,8 @@ jobs:
   test:
     name: Test & Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: check-commit
     if: |
       github.event_name == 'pull_request' ||
@@ -180,6 +183,8 @@ jobs:
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [check-commit, test]
     if: |
       needs.check-commit.outputs.should-run == 'true' &&


### PR DESCRIPTION
## Summary

- Fixes CodeQL alerts #13, #14, #15 ("Workflow does not contain permissions")
- Adds `permissions: {}` to `check-commit` (no permissions needed)
- Adds `permissions: contents: read` to `test` and `build-docs` (checkout only)

## Test plan

- [ ] CI passes on this PR
- [ ] CodeQL alerts #13, #14, #15 are resolved after merge