### PR TITLE
fix: address Dependabot CVEs — starlette 1.3.1, pyjwt 2.13.0, fastapi 0.137.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -427,25 +427,26 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.128.0"
+version = "0.137.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d"},
-    {file = "fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a"},
+    {file = "fastapi-0.137.1-py3-none-any.whl", hash = "sha256:64f6983c59e45c4b9fdc44e57cb8035c2451ee91ea8e8ec042aca37de7cf6b69"},
+    {file = "fastapi-0.137.1.tar.gz", hash = "sha256:822360704230d9533d8d9475399613525968aa2f0b5bd2a3ccc9f18c88fd541c"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
-pydantic = ">=2.7.0"
-starlette = ">=0.40.0,<0.51.0"
+pydantic = ">=2.9.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
+typing-inspection = ">=0.4.2"
 
 [package.extras]
-all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
-standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "fastar (>=0.9.0)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
@@ -1262,14 +1263,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
-    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
+    {file = "pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728"},
+    {file = "pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423"},
 ]
 
 [package.dependencies]
@@ -1277,9 +1278,6 @@ typing_extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "pytest"
@@ -1613,14 +1611,14 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "0.49.3"
+version = "1.3.1"
 description = "The little ASGI library that shines."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "examples"]
 files = [
-    {file = "starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f"},
-    {file = "starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284"},
+    {file = "starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"},
+    {file = "starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0"},
 ]
 
 [package.dependencies]
@@ -1628,7 +1626,7 @@ anyio = ">=3.6.2,<5"
 typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
-full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+full = ["httpx (>=0.27.0,<0.29.0)", "httpx2 (>=2.0.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "tomli"
@@ -2136,4 +2134,4 @@ uvloop = ["uvloop"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "e8013f62de25dc373f5fc993a26e559302f07748782ffc24d899fdc08e5e4d32"
+content-hash = "6c034caa9dfd0b3986aa6081893e113ba5184cad108b0cde1c1ef6768663fb7e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ typer = "^0.12.3"
 watchdog = "^4.0.2"
 opentelemetry-api = "^1.39.1"
 opentelemetry-exporter-prometheus = "^0.60b1"
-fastapi = "^0.128.0"
+fastapi = ">=0.128.0"
+pyjwt = ">=2.13.0"
 uvicorn = {extras = ["standard"], version = "^0.32.0"}
 redis = "^5.0.0"
 uvloop = {version = "^0.19.0", optional = true}
@@ -58,7 +59,7 @@ httpx = "^0.27.0"
 
 [tool.poetry.group.examples.dependencies]
 pydantic = "^2.10.0"
-starlette = ">=0.49.1,<0.50.0"
+starlette = ">=1.3.1"
 
 [tool.poetry.scripts]
 genesis = "genesis.cli:app"


### PR DESCRIPTION
## Summary

Addresses 13 open Dependabot security alerts by bumping three dependencies.

### Changes

| Package | Before | After | Constraint change |
|---------|--------|-------|-------------------|
| `starlette` (examples) | 0.49.3 | **1.3.1** | `>=0.49.1,<0.50.0` → `>=1.3.1` |
| `fastapi` (main) | 0.128.0 | **0.137.1** | `^0.128.0` → `>=0.128.0` |
| `pyjwt` (main, new explicit dep) | 2.12.1 | **2.13.0** | added `>=2.13.0` |

FastAPI's `^0.128.0` was silently capping at `<0.129.0` in Poetry, blocking the starlette upgrade. FastAPI 0.137.1 removed the starlette upper bound, enabling 1.x.
PyJWT is a transitive dep of `redis`; adding it explicitly as a direct dep floors the minimum to the patched version.

### Alerts resolved

**Starlette (7 alerts):**
- #28 — Critical: DoS via silently ignored urlencoded form limits
- #26 — High: SSRF + NTLM credential theft via UNC paths
- #25 — Medium: Arbitrary HTTP method dispatch via getattr
- #19 — Medium: Host header validation bypass
- #8 — Medium: O(n²) DoS via Range header merging in FileResponse
- #7 — Medium: DoS via large multipart forms
- #27 — Low: Unvalidated request path poisons `request.url.hostname`

**PyJWT (6 alerts):**
- #24 — High: Public-key JWK accepted as HMAC secret (token forgery)
- #10 — High: Accepts unknown `crit` header extensions
- #23 — Medium: PyJWKClient SSRF via unvalidated URL schemes (file://, ftp://)
- #22 — Medium: Unauthenticated DoS via Base64URL decoding in detached JWS
- #21 — Medium: Algorithm allow-list bypass with PyJWK/PyJWKClient
- #20 — Low: Unbounded JWKS endpoint requests via unknown `kid` values

The remaining ~10 alerts (urllib3, black, idna, pytest, requests, etc.) are already at their patched versions in the lock file and should auto-dismiss once Dependabot re-evaluates.

### Notes

Starlette 1.x emits a `StarletteDeprecationWarning` when `httpx` is used with `starlette.testclient` — Starlette now prefers `httpx2`. This is non-breaking and all 242 tests pass; migrating to `httpx2` can be done in a follow-up.

## Test plan

- [x] `poetry run black --check genesis/ tests/ examples/` — clean
- [x] `poetry run mypy` — clean
- [x] `poetry run pytest tests/` — 242 passed, 0 failed